### PR TITLE
Add timestamp to davesays.py

### DIFF
--- a/davesays.py
+++ b/davesays.py
@@ -4,6 +4,8 @@
 
 import cowsay
 import sys
+from datetime import datetime
 
 message = " ".join(sys.argv[1:])
-print(cowsay.get_output_string("cow", f"Dave says: {message}"))
+timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+print(cowsay.get_output_string("cow", f"Dave says ({timestamp}): {message}"))

--- a/davesays.py
+++ b/davesays.py
@@ -4,8 +4,8 @@
 
 import cowsay
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 message = " ".join(sys.argv[1:])
-timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+timestamp = datetime.now(timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
 print(cowsay.get_output_string("cow", f"Dave says ({timestamp}): {message}"))


### PR DESCRIPTION
Add current date and time to the message output in davesays.py script.

The timestamp is displayed in YYYY-MM-DD HH:MM:SS format and appears in parentheses after 'Dave says'.

Fixes #10