### PR TITLE
Fix: Add trailing newline check before appending to sleep.csv

### DIFF
--- a/.github/agents/mistral-vibe.md
+++ b/.github/agents/mistral-vibe.md
@@ -1,0 +1,22 @@
+# Mistral Vibe Agent Configuration
+
+This file documents the expected behavior for the Mistral Vibe coding agent when working on this repository.
+
+## Python Environment
+
+- **Always use Python with uv**: Use `uv run` for all Python commands, including running scripts and tests.
+- **Never .gitignore uv.lock**: The `uv.lock` file must be committed to git for repeatable builds.
+
+## Development Practices
+
+- **Use Red-Green TDD**: Follow Test-Driven Development:
+  1. Write a failing test first (Red)
+  2. Implement the fix (Green)
+  3. Refactor if needed
+- **Testing Framework**: Use `pytest` for all tests. Do not use `unittest`.
+
+## Commands
+
+- Run tests: `uv run pytest`
+- Run specific test file: `uv run pytest path/to/test_file.py -v`
+- Install dependencies: `uv pip install package_name`

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+__pycache__/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 __pycache__/*
+__pycache__/
+uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .env
 __pycache__/*
 __pycache__/
-uv.lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# utils
+
+Utility scripts repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "utils"
+version = "0.1.0"
+description = "Utility scripts"
+requires-python = ">=3.11"
+dependencies = [
+    "pytest>=8.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["sleep"]

--- a/sleep/test_track_sleep.py
+++ b/sleep/test_track_sleep.py
@@ -1,73 +1,52 @@
 #!/usr/bin/env python3
-"""Tests for track_sleep.py module."""
+"""Tests for track_sleep.py module using pytest."""
 
-import csv
 import os
 import tempfile
-import unittest
-from unittest.mock import patch
+
+import pytest
 
 from track_sleep import append_sleep_data
 
 
-class TestAppendSleepData(unittest.TestCase):
-    """Tests for the append_sleep_data function."""
-
-    def setUp(self):
-        """Create a temporary directory and CSV file for testing."""
-        self.temp_dir = tempfile.mkdtemp()
-        self.csv_path = os.path.join(self.temp_dir, "sleep.csv")
-        # Patch the CSV_FILE constant
-        self.patcher = patch('track_sleep.CSV_FILE', self.csv_path)
-        self.patcher.start()
-
-    def tearDown(self):
-        """Clean up temporary files and patches."""
-        self.patcher.stop()
-        if os.path.exists(self.csv_path):
-            os.remove(self.csv_path)
-        os.rmdir(self.temp_dir)
-
-    def test_append_to_new_file(self):
-        """Test appending to a non-existent file creates it with header."""
-        append_sleep_data("01-Jan-24", "y", 80)
-        
-        with open(self.csv_path, 'r') as f:
-            contents = f.read()
-        
-        expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n"
-        self.assertEqual(contents, expected)
-
-    def test_append_to_existing_file_with_trailing_newline(self):
-        """Test appending to a file that has a trailing newline."""
-        # Create file with trailing newline
-        with open(self.csv_path, 'w') as f:
-            f.write("Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n")
-        
-        append_sleep_data("02-Jan-24", "n", 75)
-        
-        with open(self.csv_path, 'r') as f:
-            contents = f.read()
-        
-        expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n02-Jan-24,n,75\n"
-        self.assertEqual(contents, expected)
-
-    def test_append_to_existing_file_without_trailing_newline(self):
-        """Test appending to a file that does NOT have a trailing newline."""
-        # Create file WITHOUT trailing newline
-        with open(self.csv_path, 'w') as f:
-            f.write("Date woke,Taped,Sleep Score\n01-Jan-24,y,80")
-        
-        append_sleep_data("02-Jan-24", "n", 75)
-        
-        with open(self.csv_path, 'r') as f:
-            contents = f.read()
-        
-        # This should NOT have the new data appended to the last line
-        # Each row should be on its own line
-        expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n02-Jan-24,n,75\n"
-        self.assertEqual(contents, expected)
+@pytest.fixture
+def temp_csv_file(monkeypatch, tmp_path):
+    """Fixture to create a temporary CSV file path and patch CSV_FILE constant."""
+    csv_path = tmp_path / "sleep.csv"
+    monkeypatch.setattr("track_sleep.CSV_FILE", str(csv_path))
+    return csv_path
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_append_to_new_file(temp_csv_file):
+    """Test appending to a non-existent file creates it with header."""
+    append_sleep_data("01-Jan-24", "y", 80)
+    
+    contents = temp_csv_file.read_text()
+    expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n"
+    assert contents == expected
+
+
+def test_append_to_existing_file_with_trailing_newline(temp_csv_file):
+    """Test appending to a file that has a trailing newline."""
+    # Create file with trailing newline
+    temp_csv_file.write_text("Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n")
+    
+    append_sleep_data("02-Jan-24", "n", 75)
+    
+    contents = temp_csv_file.read_text()
+    expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n02-Jan-24,n,75\n"
+    assert contents == expected
+
+
+def test_append_to_existing_file_without_trailing_newline(temp_csv_file):
+    """Test appending to a file that does NOT have a trailing newline."""
+    # Create file WITHOUT trailing newline
+    temp_csv_file.write_text("Date woke,Taped,Sleep Score\n01-Jan-24,y,80")
+    
+    append_sleep_data("02-Jan-24", "n", 75)
+    
+    contents = temp_csv_file.read_text()
+    # This should NOT have the new data appended to the last line
+    # Each row should be on its own line
+    expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n02-Jan-24,n,75\n"
+    assert contents == expected

--- a/sleep/test_track_sleep.py
+++ b/sleep/test_track_sleep.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Tests for track_sleep.py module."""
+
+import csv
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from track_sleep import append_sleep_data
+
+
+class TestAppendSleepData(unittest.TestCase):
+    """Tests for the append_sleep_data function."""
+
+    def setUp(self):
+        """Create a temporary directory and CSV file for testing."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.csv_path = os.path.join(self.temp_dir, "sleep.csv")
+        # Patch the CSV_FILE constant
+        self.patcher = patch('track_sleep.CSV_FILE', self.csv_path)
+        self.patcher.start()
+
+    def tearDown(self):
+        """Clean up temporary files and patches."""
+        self.patcher.stop()
+        if os.path.exists(self.csv_path):
+            os.remove(self.csv_path)
+        os.rmdir(self.temp_dir)
+
+    def test_append_to_new_file(self):
+        """Test appending to a non-existent file creates it with header."""
+        append_sleep_data("01-Jan-24", "y", 80)
+        
+        with open(self.csv_path, 'r') as f:
+            contents = f.read()
+        
+        expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n"
+        self.assertEqual(contents, expected)
+
+    def test_append_to_existing_file_with_trailing_newline(self):
+        """Test appending to a file that has a trailing newline."""
+        # Create file with trailing newline
+        with open(self.csv_path, 'w') as f:
+            f.write("Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n")
+        
+        append_sleep_data("02-Jan-24", "n", 75)
+        
+        with open(self.csv_path, 'r') as f:
+            contents = f.read()
+        
+        expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n02-Jan-24,n,75\n"
+        self.assertEqual(contents, expected)
+
+    def test_append_to_existing_file_without_trailing_newline(self):
+        """Test appending to a file that does NOT have a trailing newline."""
+        # Create file WITHOUT trailing newline
+        with open(self.csv_path, 'w') as f:
+            f.write("Date woke,Taped,Sleep Score\n01-Jan-24,y,80")
+        
+        append_sleep_data("02-Jan-24", "n", 75)
+        
+        with open(self.csv_path, 'r') as f:
+            contents = f.read()
+        
+        # This should NOT have the new data appended to the last line
+        # Each row should be on its own line
+        expected = "Date woke,Taped,Sleep Score\n01-Jan-24,y,80\n02-Jan-24,n,75\n"
+        self.assertEqual(contents, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sleep/track_sleep.py
+++ b/sleep/track_sleep.py
@@ -35,14 +35,22 @@ def get_user_input():
 def append_sleep_data(date, taped, score):
     """Append a new row to the sleep CSV file."""
     file_exists = False
+    needs_newline = False
     try:
         with open(CSV_FILE, 'r', newline='') as f:
             file_exists = True
+            content = f.read()
+            # Check if file doesn't end with a newline
+            if content and not content.endswith('\n'):
+                needs_newline = True
     except FileNotFoundError:
         pass
     
     # Open in append mode with newline='' to let csv writer handle line endings
     with open(CSV_FILE, 'a', newline='') as f:
+        # Add missing newline before appending if needed
+        if needs_newline:
+            f.write('\n')
         writer = csv.writer(f)
         # Write header if file didn't exist
         if not file_exists:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,75 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", specifier = ">=8.0.0" }]


### PR DESCRIPTION
Fixes #17 - Sleep tracker now checks if sleep.csv has a trailing newline before appending new data. If the file doesn't end with a newline, one is added before the new row to prevent data from being appended to the last line.

Changes:
- Added test_track_sleep.py with TDD tests reproducing the issue
- Modified append_sleep_data() to check for trailing newline
- Updated .gitignore to exclude __pycache__